### PR TITLE
Rename project to "pymol-open-source-whl" and bump version to 3.1.0.4…

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -15,9 +15,9 @@
 name: Build Wheels
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - scikit_build_core
 
 env:
   VCPKG_ROOT: ${{ github.workspace }}/vendor/vcpkg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ requires = [
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "pymol"
+name = "pymol-open-source-whl"
 readme = "README.md"
-version = "3.1.0.3"
+version = "3.1.0.4"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
 #description = """


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the project name and version.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R12): Changed the project name from `pymol` to `pymol-open-source-whl` and updated the version from `3.1.0.3` to `3.1.0.4`.… in pyproject.toml